### PR TITLE
Fix README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Make sure you have Python 3.10+ installed.
 Verify that FFmpeg is installed and added to your system PATH.
 
 Open a terminal in the project folder:
-cd WhisperTranscriberProject
+cd Whisper-GUI
 
 
 If you lack the required packages (e.g., first time user), use the “Install Requirements” button in the app or run:


### PR DESCRIPTION
## Summary
- fix directory name in setup instructions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f9f67566c8330b4f7e30877d76f48