### PR TITLE
Fix project folder name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Make sure you have Python 3.10+ installed.
 Verify that FFmpeg is installed and added to your system PATH.
 
 Open a terminal in the project folder:
-cd WhisperTranscriberProject
+cd Whisper-GUI
 
 
 If you lack the required packages (e.g., first time user), use the “Install Requirements” button in the app or run:


### PR DESCRIPTION
## Summary
- update the run instructions to use the correct folder name

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fa3aa4e888330b82dc32148940a24