### PR TITLE
Fix transcriber line endings and add messagebox import

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -1,14 +1,15 @@
-import os␊
-import sys␊
-import queue␊
-import threading␊
-import subprocess␊
-import torch␊
-import whisper␊
-import time  # Eksik import tamamlandı␊
-␊
+import os
+import sys
+import queue
+import threading
+import subprocess
+import torch
+import whisper
+import time  # Eksik import tamamlandı
+from tkinter import messagebox
+
 from config import MODEL_FOLDER
-os.makedirs(MODEL_FOLDER, exist_ok=True)  # Ensure model folder exists␊
+os.makedirs(MODEL_FOLDER, exist_ok=True)  # Ensure model folder exists
 
 MODEL_LIST = [
     "tiny", "tiny.en",


### PR DESCRIPTION
## Summary
- strip stray `␊` characters and convert newlines to CRLF
- add missing `messagebox` import in `transcriber.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fae26a6f483308a07dd2e5cc28311