### PR TITLE
Add HuggingFace model download for Whisper Turbo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ psutil
 gputil
 googletrans==4.0.0-rc1
 fpdf
+huggingface_hub

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -5,6 +5,7 @@ from unittest import mock
 # imported without installing these packages.
 sys.modules.setdefault('torch', mock.MagicMock())
 sys.modules.setdefault('whisper', mock.MagicMock())
+sys.modules.setdefault('huggingface_hub', mock.MagicMock())
 
 import builtins
 import transcriber

--- a/transcriber.py
+++ b/transcriber.py
@@ -5,6 +5,7 @@ import threading
 import subprocess
 import torch
 import whisper
+from huggingface_hub import snapshot_download
 import time  # Eksik import tamamlandı
 from tkinter import messagebox, filedialog
 
@@ -67,7 +68,16 @@ def run_transcription(q, stop_evt, model_name, audio_file):
                 q.put(("Warning", f"Model dosyasi bulunamadi: {model_name}."))
                 return
 
-        model = whisper.load_model(model_name, device=device, download_root=MODEL_FOLDER)
+        if model_name == "whisper-turbo":
+            repo_id = "whisper-turbo"
+            model_path = snapshot_download(
+                repo_id=repo_id,
+                local_dir=MODEL_FOLDER,
+                local_dir_use_symlinks=False,
+            )
+            model = whisper.load_model(model_path, device=device)
+        else:
+            model = whisper.load_model(model_name, device=device, download_root=MODEL_FOLDER)
         
         if stop_evt.is_set():
             q.put(("StoppedBeforeTranscribe", None))


### PR DESCRIPTION
## Notes
- `huggingface_hub` eklendi ve testlerde bu kütüphane mocklandı.
- `run_transcription` fonksiyonu Whisper Turbo modelini HuggingFace üzerinden indirip yükleyecek şekilde güncellendi.

## Summary
- `whisper-turbo` modeli için HuggingFace üzerinden indirme desteği eklendi.
- `requirements.txt` içerisine `huggingface_hub` eklendi.
- Test dosyası, yeni bağımlılık için mock ayarlanarak güncellendi.

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fba1bf5a483309f0c00d4553faa74