### PR TITLE
Sync MODEL_LIST usage

### DIFF
--- a/transcriber.py
+++ b/transcriber.py
@@ -9,7 +9,7 @@ from huggingface_hub import snapshot_download
 import time  # Eksik import tamamlandı
 from tkinter import messagebox, filedialog
 
-from config import MODEL_FOLDER, MODEL_REQUIREMENTS, HUGGINGFACE_REPOS, HF_TOKEN
+from config import MODEL_FOLDER, MODEL_REQUIREMENTS, HUGGINGFACE_REPOS, HF_TOKEN, MODEL_LIST
 os.makedirs(MODEL_FOLDER, exist_ok=True)  # Ensure model folder exists
 
 
@@ -28,13 +28,6 @@ def ensure_model_folder():
             os.makedirs(MODEL_FOLDER, exist_ok=True)
 
 
-MODEL_LIST = [
-    "tiny", "tiny.en",
-    "base", "base.en",
-    "small", "small.en",
-    "medium", "medium.en",
-    "large", "large-v2", "large-v3", "whisper-turbo"
-]
 
 def check_requirements():
     missing_modules = []

--- a/ui.py
+++ b/ui.py
@@ -8,6 +8,7 @@ import psutil
 import GPUtil
 import logging
 from datetime import datetime
+from config import MODEL_LIST
 from transcriber import check_requirements, install_requirements, transcribe
 
 # Dil cevirileri
@@ -253,7 +254,7 @@ def create_main_window():
     model_label = tk.Label(left_frame, text=lang["select_model"], bg="#1E1E2E", fg="white")
     model_label.pack(pady=5)
     model_var = tk.StringVar(value="base")
-    model_menu = ttk.Combobox(left_frame, textvariable=model_var, values=["tiny", "base", "small", "medium", "large", "large-v2", "large-v3", "whisper-turbo"], width=18, state="readonly")
+    model_menu = ttk.Combobox(left_frame, textvariable=model_var, values=MODEL_LIST, width=18, state="readonly")
     model_menu.pack(pady=5)
 
     # Transcription Buttons


### PR DESCRIPTION
## Summary
- share MODEL_LIST across modules via config
- import MODEL_LIST in transcriber and ui modules
- reference MODEL_LIST for model menu values

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc127d61c8330bcdcce38f52d265c