### PR TITLE
Model boyutları ve mesaj güncellemesi

### DIFF
--- a/config.py
+++ b/config.py
@@ -61,6 +61,11 @@ MODEL_REQUIREMENTS = {
         "notes": "Medium model",
         "size": "1.5GB",
     },
+    "medium.en": {
+        "ram": "8GB+",
+        "notes": "English-only version",
+        "size": "1.5GB",
+    },
     "large": {
         "ram": "12GB+",
         "notes": "Large model",
@@ -74,7 +79,7 @@ MODEL_REQUIREMENTS = {
     "large-v3": {
         "ram": "16GB+",
         "notes": "Newest large model",
-        "size": "2.9GB",
+        "size": "3.1GB",
     },
     "whisper-turbo": {
         "ram": "8GB+",

--- a/transcriber.py
+++ b/transcriber.py
@@ -72,7 +72,7 @@ def run_transcription(q, stop_evt, model_name, audio_file):
             size = MODEL_REQUIREMENTS.get(model_name, {}).get("size", "bilinmiyor")
             if not messagebox.askyesno(
                 "Eksik Model",
-                f"{model_name} modeli (~{size}) indirilecek. Onaylıyor musunuz?",
+                f"{model_name} modeli (yaklaşık {size}) indirilecek. Onaylıyor musunuz?",
             ):
                 q.put(("Warning", f"Model dosyasi bulunamadi: {model_name}."))
                 return


### PR DESCRIPTION
## Özellikler
- `MODEL_REQUIREMENTS` sözlüğüne `medium.en` için eksik olan giriş eklendi ve `large-v3` boyutu 3.1GB olarak güncellendi.
- Eksik model uyarısında indirme boyutunun tahmini olduğunu vurgulamak için "yaklaşık" kelimesi eklendi.

## Testler
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fc3a43b7c833090b0b13ae1481a56