### PR TITLE
Yeni fonksiyon: get_installed_models

### DIFF
--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -84,3 +84,13 @@ def test_create_main_window_missing_warning():
         args, _ = mock_warn.call_args
         assert 'psutil' in args[1]
         assert 'fpdf' in args[1]
+
+
+def test_get_installed_models(tmp_path, monkeypatch):
+    monkeypatch.setattr(transcriber, 'MODEL_FOLDER', str(tmp_path))
+    (tmp_path / 'base.pt').touch()
+    (tmp_path / 'medium.bin').touch()
+    (tmp_path / 'readme.txt').touch()
+
+    models = transcriber.get_installed_models()
+    assert sorted(models) == ['base', 'medium']

--- a/transcriber.py
+++ b/transcriber.py
@@ -27,6 +27,17 @@ def ensure_model_folder():
             os.makedirs(MODEL_FOLDER, exist_ok=True)
 
 
+def get_installed_models():
+    """MODEL_FOLDER içindeki .pt veya .bin uzantılı dosyalardan model adlarını döndür."""
+    models = []
+    if os.path.isdir(MODEL_FOLDER):
+        for fname in os.listdir(MODEL_FOLDER):
+            base, ext = os.path.splitext(fname)
+            if ext in {".pt", ".bin"}:
+                models.append(base)
+    return models
+
+
 
 def check_requirements():
     missing_modules = []


### PR DESCRIPTION
## Summary
- MODEL_FOLDER altindaki `.pt` ve `.bin` dosyalarini tarayarak kurulu modelleri listeleyen `get_installed_models` fonksiyonunu ekle
- fonksiyon icin birim testi eklendi

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcefbb27883308c1a6ecdaba98775