### PR TITLE
Add model download menu

### DIFF
--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -94,3 +94,12 @@ def test_get_installed_models(tmp_path, monkeypatch):
 
     models = transcriber.get_installed_models()
     assert sorted(models) == ['base', 'medium']
+
+
+def test_download_model_uses_load_model(monkeypatch):
+    mock_load = mock.MagicMock()
+    monkeypatch.setattr(transcriber, 'whisper', mock.MagicMock(load_model=mock_load))
+    monkeypatch.setattr(transcriber, 'messagebox', mock.MagicMock(askyesno=mock.MagicMock(return_value=False)))
+    monkeypatch.setattr(transcriber, 'filedialog', mock.MagicMock())
+    transcriber.download_model('base')
+    mock_load.assert_called_once_with('base', device='cpu', download_root=transcriber.MODEL_FOLDER)

--- a/transcriber.py
+++ b/transcriber.py
@@ -116,3 +116,9 @@ def transcribe(q, stop_event, model_name, selected_file):
         args=(q, stop_event, model_name, selected_file),
         daemon=True
     ).start()
+
+
+def download_model(model_name):
+    """Download the given Whisper model to MODEL_FOLDER."""
+    ensure_model_folder()
+    whisper.load_model(model_name, device="cpu", download_root=MODEL_FOLDER)


### PR DESCRIPTION
## Summary
- yeni `download_model` fonksiyonuyla modelleri indir
- `ui.create_main_window` içinde kurulu ve indirilebilir model listeleri için iki ayrı açılır menü ekle
- indir butonuna basınca seçilen model indirilip listeler güncelleniyor
- yeni işlev için test ekle

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fd02cea748330bc03893607266eaf