### PR TITLE
Set English as default language

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -134,7 +134,7 @@ class TextHandler(logging.Handler):
 
 def create_main_window():
     root = tk.Tk()
-    language_var = tk.StringVar(value="tr")
+    language_var = tk.StringVar(value="en")
     lang = translations[language_var.get()]
     root.title(lang["title"])
     root.geometry("1200x800")


### PR DESCRIPTION
## Summary
- use `en` as the default language on startup

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684fd9c8494083309520a1d0e07f8fc1