### PR TITLE
Güncellenmiş model klasörü ayarı

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,8 @@ warnings.filterwarnings("ignore", category=FutureWarning)
 warnings.filterwarnings("ignore", message="FP16 is not supported on CPU; using FP32 instead")
 
 # 🔹 Model klasörü ayarı
-MODEL_FOLDER = os.path.join(os.path.expanduser("~"), "Desktop", "WhisperPy", "Models")
+# Uygulama dizini altındaki 'WhisperModels' klasörünü kullan
+MODEL_FOLDER = os.path.join(os.path.dirname(os.path.abspath(__file__)), "WhisperModels")
 os.makedirs(MODEL_FOLDER, exist_ok=True)  # Eğer klasör yoksa oluştur
 
 # 🔹 Transkripsiyon klasörü ayarı

--- a/transcriber.py
+++ b/transcriber.py
@@ -13,18 +13,8 @@ os.makedirs(MODEL_FOLDER, exist_ok=True)  # Ensure model folder exists
 
 
 def ensure_model_folder():
-    """Check model folder and optionally let the user choose a new one."""
-    global MODEL_FOLDER
-    if not os.path.isdir(MODEL_FOLDER):
-        os.makedirs(MODEL_FOLDER, exist_ok=True)
-    if messagebox.askyesno(
-        "Model Klasörü",
-        f"Model klasörü olarak '{MODEL_FOLDER}' kullanılacak. Değiştirmek ister misiniz?",
-    ):
-        new_dir = filedialog.askdirectory(initialdir=MODEL_FOLDER)
-        if new_dir:
-            MODEL_FOLDER = new_dir
-            os.makedirs(MODEL_FOLDER, exist_ok=True)
+    """MODEL_FOLDER klasörünün mevcut olduğundan emin ol."""
+    os.makedirs(MODEL_FOLDER, exist_ok=True)
 
 
 def get_installed_models():


### PR DESCRIPTION
## Summary
- MODEL_FOLDER artık uygulama dizini altındaki `WhisperModels` klasörünü kullanıyor
- `ensure_model_folder` fonksiyonu sadeleştirildi ve klasör yoksa oluşturuyor
- testler başarıyla çalışıyor

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fdf15514483309a877d106d8640ce