### PR TITLE
Use multi_cell for PDF export

### DIFF
--- a/ui.py
+++ b/ui.py
@@ -373,10 +373,11 @@ def create_main_window():
             messagebox.showerror("Error", lang["fpdf_error"])
             return
         pdf = FPDF()
+        pdf.set_auto_page_break(auto=True, margin=15)
         pdf.add_page()
         pdf.set_font("Arial", size=12)
         for line in text.splitlines():
-            pdf.cell(0, 10, line, ln=1)
+            pdf.multi_cell(0, 10, line)
         pdf.output(pdf_path)
         messagebox.showinfo(lang["info"], "PDF ve TXT dosyaları program klasörüne kaydedildi")
 


### PR DESCRIPTION
## Summary
- allow long text wrapping in PDF exports

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fe58b3c208330b6d9dde395d51d23